### PR TITLE
Fix https://github.com/rubys/wunderbar/issues/11

### DIFF
--- a/lib/wunderbar/builder.rb
+++ b/lib/wunderbar/builder.rb
@@ -461,8 +461,14 @@ module Wunderbar
       output_prefix = opts[:prefix] || {}
       output_prefix[:stdin]  ||= '$ '
 
-      super do |kind, line|
-        @_target.puts "#{output_prefix[kind]}#{line}"
+      if Hash === args.last # support original code which needed two hashes
+        super do |kind, line|
+          @_target.puts "#{output_prefix[kind]}#{line}"
+        end
+      else
+        super(*args, opts) do |kind, line|
+          @_target.puts "#{output_prefix[kind]}#{line}"
+        end
       end
     end
 
@@ -587,8 +593,14 @@ module Wunderbar
         @_target[transcript] = []
       end
 
-      super do |kind, line|
-        @_target[transcript] << "#{output_prefix[kind]}#{line}"
+      if Hash === args.last # support original code which needed two hashes
+        super do |kind, line|
+          @_target[transcript] << "#{output_prefix[kind]}#{line}"
+        end
+      else
+        super(*args, opts) do |kind, line|
+          @_target[transcript] << "#{output_prefix[kind]}#{line}"
+        end
       end
     end
 


### PR DESCRIPTION
Existing code may be using two hashes for JSON and Text System methods.
If the code is unconditionally changed to use a single hash, such code will break as the BuilderClass only expects a single trailing hash.

This patch checks for two trailing hashes, and if so, keeps the existing code.

Otherwise, the single has is passed to the parent class.