### PR TITLE
Revert to html_safe? handling as per 1.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,16 @@ Secure by default
 
 Wunderbar will properly escape all HTML and JSON output, eliminating problems
 of HTML or JavaScript injection.  This includes calls to `_` to insert text
-directly.
+directly.  Unless `nokogiri` was previously required (see [optional
+dependencies](#optional-dependencies) below), calls to insert markup
+(`_{...}`) will escape the markup if the input is `tainted` and not explicitly
+marked as `html_safe?` (when using Rails).
+
+A special feature that effectively is only available in the Rails environment:
+if the first argument to call that creates an element is `html_safe?`, then
+that argument will be treated as a markup instead of as text.  This allows one
+to make calls like `_td link_to...` without placing the call to `link_to` in a
+block.
 
 Globals provided
 ---
@@ -435,6 +444,7 @@ The following gems, if installed, will produce cleaner and prettier output:
 * `nokogumbo` also cleans up HTML fragments inserted via `<<` and `_{}`.  If
   this gem is available, it will be preferred over direct usage of `nokogiri`.
 * `escape` prettier quoting of `system` commands
+* `sanitize` will remove unsafe markup from tainted input
 
 Related efforts
 ---

--- a/lib/wunderbar/version.rb
+++ b/lib/wunderbar/version.rb
@@ -2,7 +2,7 @@ module Wunderbar
   module VERSION #:nodoc:
     MAJOR = 1
     MINOR = 4
-    TINY  = 3
+    TINY  = 4
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/test/test_html_markup.rb
+++ b/test/test_html_markup.rb
@@ -128,6 +128,31 @@ class HtmlMarkupTest < MiniTest::Test
       a:before\s\{content:\s"<"\}\s+/\*\]\]>\*/</style>]x, target
   end
 
+  def test_safe_markup
+    markup = "<b>bold</b>"
+    def markup.html_safe?
+      true
+    end
+    @x.html {_p markup}
+    assert_match %r[<p>\n {6}<b>bold</b>\n {4}</p>], target
+  end
+
+  def test_safe_markup_unsafe
+    markup = "<b>bold</b>"
+    def markup.html_safe?
+      false
+    end
+    @x.html {_p markup}
+    assert_match %r[<p>&lt;b&gt;bold&lt;/b&gt;</p>], target
+  end
+
+  def test_safe_markup_undefined
+    markup = "<b>bold</b>"
+    @x.html {_p markup}
+    assert_match %r[<p>&lt;b&gt;bold&lt;/b&gt;</p>], target
+  end
+
+
   def test_disable_indent
     @x.html {_div! {_ "one "; _strong "two"; _ " three"}}
     assert_match %r[<div>one <strong>two</strong> three</div>], target
@@ -373,6 +398,11 @@ class HtmlMarkupTest < MiniTest::Test
   def test_literal_markup
     @x.html {_{"<p>one</p>\n\n<p>two</p>\n"}}
     assert_match %r[^( +)<p>one</p>\n\n\1<p>two</p>], target
+  end
+
+  def test_markup
+    @x.html { _ '<3' } # as per README
+    assert_match %r{^( +)&lt;3}, target
   end
 
   def test_proc


### PR DESCRIPTION
Also add some new tests for markup escaping