### PR TITLE
Bundle lines for output display

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ The `_.system` method takes an optional hash as its last parameter. This can be 
 [Process.spawn](https://www.rubydoc.info/stdlib/core/Process.spawn) method.
 For example: `._system('pwd',{ system_opts: { chdir: dir } , system_env: { 'FOO' => 'BAR' } })`
 Note that environment variable names must be provided as strings, not symbols.
+Additional options that can be used with `_.system` include:
+* `:tag` - the HTML tag to be used for input/output; defaults to `pre`
+* `:bundlelines` - whether to process all the lines for a given output type (stderr, stdout, etc ) as part of single tag. If not specified, defaults to `true` for `pre` tags and `false` otherwise. If `false`, each line of output is processed separately.
 
 Access to all of the builder _defined_ methods (typically these end in an exclamation mark) and all of the Wunderbar module methods can be accessed in this way.  Examples:
 

--- a/test/test_html_markup.rb
+++ b/test/test_html_markup.rb
@@ -446,6 +446,45 @@ class HtmlMarkupTest < MiniTest::Test
     assert_match %r[<pre class=\"_stdout\">hi</pre>], target
   end
 
+  def test_system_multiline_pre_default
+    @x.html {_.system ['ls', '-d1', '.', '..']} # generate two lines of output
+    assert_match %r[<pre class="_stdin">ls -d1 . ..</pre>], target
+    assert_match %r[<pre class="_stdout">.\n..</pre>], target
+  end
+
+  def test_system_multiline_pre_true
+    @x.html {_.system ['ls', '-d1', '.', '..'], {bundlelines: true}} # generate two lines of output
+    assert_match %r[<pre class="_stdin">ls -d1 . ..</pre>], target
+    assert_match %r[<pre class="_stdout">.\n..</pre>], target
+  end
+
+  def test_system_multiline_pre_false
+    @x.html {_.system ['ls', '-d1', '.', '..'], {bundlelines: false}}
+    assert_match %r[<pre class="_stdin">ls -d1 . ..</pre>], target
+    assert_match %r[<pre class="_stdout">.</pre>], target
+    assert_match %r[<pre class="_stdout">..</pre>], target
+  end
+
+  def test_system_multiline_code_default
+    @x.html {_.system ['ls', '-d1', '.', '..'], {tag: 'code'}}
+    assert_match %r[<code class="_stdin">ls -d1 . ..</code>], target
+    assert_match %r[<code class="_stdout">.</code>], target
+    assert_match %r[<code class="_stdout">..</code>], target
+  end
+
+  def test_system_multiline_code_false
+    @x.html {_.system ['ls', '-d1', '.', '..'], {tag: 'code', bundlelines: false}}
+    assert_match %r[<code class="_stdin">ls -d1 . ..</code>], target
+    assert_match %r[<code class="_stdout">.</code>], target
+    assert_match %r[<code class="_stdout">..</code>], target
+  end
+
+  def test_system_multiline_code_true
+    @x.html {_.system ['ls', '-d1', '.', '..'], {tag: 'code', bundlelines: true}}
+    assert_match %r[<code class="_stdin">ls -d1 . ..</code>], target
+    assert_match %r[<code class="_stdout">.\n..</code>], target
+  end
+
   def test_system_opts
     Dir.mktmpdir do |dir|
       @x.html {_.system ['pwd'], { system_opts: { chdir: dir} }}

--- a/test/test_html_markup.rb
+++ b/test/test_html_markup.rb
@@ -447,40 +447,52 @@ class HtmlMarkupTest < MiniTest::Test
   end
 
   def test_system_multiline_pre_default
-    @x.html {_.system ['ls', '-d1', '.', '..']} # generate two lines of output
+    rc = nil
+    @x.html {rc = _.system ['ls', '-d1', '.', '..']} # generate two lines of output
+    assert_equal rc, 0
     assert_match %r[<pre class="_stdin">ls -d1 . ..</pre>], target
     assert_match %r[<pre class="_stdout">.\n..</pre>], target
   end
 
   def test_system_multiline_pre_true
-    @x.html {_.system ['ls', '-d1', '.', '..'], {bundlelines: true}} # generate two lines of output
+    rc = nil
+    @x.html {rc = _.system ['ls', '-d1', '.', '..'], {bundlelines: true}} # generate two lines of output
+    assert_equal rc, 0
     assert_match %r[<pre class="_stdin">ls -d1 . ..</pre>], target
     assert_match %r[<pre class="_stdout">.\n..</pre>], target
   end
 
   def test_system_multiline_pre_false
-    @x.html {_.system ['ls', '-d1', '.', '..'], {bundlelines: false}}
+    rc = nil
+    @x.html {rc = _.system ['ls', '-d1', '.', '..'], {bundlelines: false}}
+    assert_equal rc, 0
     assert_match %r[<pre class="_stdin">ls -d1 . ..</pre>], target
     assert_match %r[<pre class="_stdout">.</pre>], target
     assert_match %r[<pre class="_stdout">..</pre>], target
   end
 
   def test_system_multiline_code_default
-    @x.html {_.system ['ls', '-d1', '.', '..'], {tag: 'code'}}
+    rc = nil
+    @x.html {rc = _.system ['ls', '-d1', '.', '..'], {tag: 'code'}}
+    assert_equal rc, 0
     assert_match %r[<code class="_stdin">ls -d1 . ..</code>], target
     assert_match %r[<code class="_stdout">.</code>], target
     assert_match %r[<code class="_stdout">..</code>], target
   end
 
   def test_system_multiline_code_false
-    @x.html {_.system ['ls', '-d1', '.', '..'], {tag: 'code', bundlelines: false}}
+    rc = nil
+    @x.html {rc = _.system ['ls', '-d1', '.', '..'], {tag: 'code', bundlelines: false}}
+    assert_equal rc, 0
     assert_match %r[<code class="_stdin">ls -d1 . ..</code>], target
     assert_match %r[<code class="_stdout">.</code>], target
     assert_match %r[<code class="_stdout">..</code>], target
   end
 
   def test_system_multiline_code_true
-    @x.html {_.system ['ls', '-d1', '.', '..'], {tag: 'code', bundlelines: true}}
+    rc = nil
+    @x.html {rc = _.system ['ls', '-d1', '.', '..'], {tag: 'code', bundlelines: true}}
+    assert_equal rc, 0
     assert_match %r[<code class="_stdin">ls -d1 . ..</code>], target
     assert_match %r[<code class="_stdout">.\n..</code>], target
   end


### PR DESCRIPTION
The 'pre' output for HTML looks a bit disjointed when stdout contains several lines.
Add option to bundle these lines in the same tag to keep them together visually
The default is to do this for 'pre' tags, but this can be overridden with the :bundlelines option